### PR TITLE
Stringify doc in localStorageTest()

### DIFF
--- a/tester.js
+++ b/tester.js
@@ -87,7 +87,7 @@ function createTester() {
   }
   function localStorageTest(docs) {
     for (var i = 0; i < docs.length; i++) {
-      localStorage['doc_' + i] = docs[i];
+      localStorage['doc_' + i] = JSON.stringify(docs[i]);
     }
   }
 


### PR DESCRIPTION
`localStorage` can only store strings, thus the document is casted to a string automatically (`[object Object]`) and the test is not accurate, as other DB engines store the actual document.
